### PR TITLE
Add static Raid Arena Tracker web app with localStorage + IndexedDB backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-# raid-arena-tracker
+# Raid Arena Tracker - Classic 4v4
+
+Mini web app statique (HTML/CSS/JS vanilla) pour suivre tes combats **Classic Arena Raid: Shadow Legends**.
+
+- ✅ 100% local (aucun backend)
+- ✅ Données stockées dans le navigateur via `localStorage`
+- ✅ Backup automatique supplémentaire dans le profil navigateur (`IndexedDB`)
+- ✅ Export/Import JSON pour backup et synchronisation manuelle entre appareils
+
+## Installation et lancement
+
+### Option 1 — Local (le plus simple)
+1. Clone le repo :
+   ```bash
+   git clone <url-du-repo>
+   cd raid-arena-tracker
+   ```
+2. Ouvre `index.html` dans ton navigateur (double-clic ou glisser-déposer).
+
+### Option 2 — GitHub Pages
+1. Push le repo sur GitHub.
+2. Active **Settings → Pages** sur la branche principale.
+3. Ouvre l'URL GitHub Pages fournie.
+
+> Les données restent propres à chaque navigateur/appareil, même via GitHub Pages.
+
+## Utilisation
+
+### Ajouter un combat
+- Remplis la team joueur (**1 à 4 champions**, séparés par virgules)
+- Team adverse (optionnelle, mais si remplie : **1 à 4**)
+- Rank joueur
+- Rank adverse (optionnel)
+- Victoire : Oui/Non
+- Clique **Ajouter**
+
+Les noms de champions sont automatiquement convertis en **Title Case**.
+
+## Sauvegarde et synchronisation
+
+### Export JSON
+- Clique **Exporter JSON**
+- Le fichier `raid-arena-data.json` est téléchargé
+
+### Import JSON
+- Clique **Importer JSON**
+- Sélectionne un fichier JSON précédemment exporté
+- Les données locales sont remplacées par le contenu importé
+
+## Effacer toutes les données
+
+Ouvre la console navigateur et exécute :
+
+```js
+localStorage.removeItem('raid_arena_fights');
+```
+
+Puis recharge la page.
+
+Pour vider aussi le backup interne (`IndexedDB`), ouvre DevTools → Application/Storage → IndexedDB et supprime
+la base `raid_arena_tracker_backup`.
+
+## Où sont stockées les données sous Windows ?
+
+L'app est 100% statique: elle écrit automatiquement dans le **profil du navigateur Windows** (pas dans un backend).
+
+- `localStorage`: clé `raid_arena_fights`
+- Backup interne: base IndexedDB `raid_arena_tracker_backup`
+
+Emplacements typiques (gérés par le navigateur):
+
+- Chrome: `%LOCALAPPDATA%\Google\Chrome\User Data\Default\Local Storage` et `...\IndexedDB`
+- Edge: `%LOCALAPPDATA%\Microsoft\Edge\User Data\Default\Local Storage` et `...\IndexedDB`
+- Firefox: `%APPDATA%\Mozilla\Firefox\Profiles\<profil>\storage\default`
+
+> Important: ce n'est pas un fichier JSON directement éditable, c'est du stockage interne navigateur.
+> Pour obtenir un vrai fichier JSON portable, utilise le bouton **Exporter JSON**.
+
+## Schéma des données
+
+Clé localStorage utilisée :
+
+- `raid_arena_fights`
+
+Chaque combat :
+
+```json
+{
+  "timestamp": 1730000000000,
+  "player_team": ["Arbiter", "Duchess Lilitu", "Mithrala", "Rotos"],
+  "opponent_team": ["Siphi", "Rotos"],
+  "player_rank_str": "G3",
+  "opponent_rank_str": "Plat",
+  "win": true
+}
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Raid Arena Tracker - Classic 4v4</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="app-header">
+        <h1>Raid Arena Tracker - Classic 4v4</h1>
+        <p class="subtitle">Suivi local de tes combats (stockage 100% navigateur)</p>
+        <p class="subtitle">
+          Sauvegarde automatique dans le profil navigateur Windows (localStorage + backup interne)
+        </p>
+      </header>
+
+      <section class="card" aria-labelledby="add-fight-title">
+        <h2 id="add-fight-title">Ajouter combat</h2>
+        <form id="fight-form" novalidate>
+          <div class="form-grid">
+            <label>
+              Team joueur (1 à 4 champions)
+              <input
+                type="text"
+                id="player-team"
+                required
+                placeholder="Arbiter, Duchess Lilitu, Mithrala, Rotos"
+              />
+            </label>
+
+            <label>
+              Team adverse (optionnel, 1 à 4)
+              <input
+                type="text"
+                id="opponent-team"
+                placeholder="Siphi, Rotos"
+              />
+            </label>
+
+            <label>
+              Rank joueur
+              <input type="text" id="player-rank" required placeholder="G3, Plat, S1, B4" />
+            </label>
+
+            <label>
+              Rank adverse (optionnel)
+              <input type="text" id="opponent-rank" placeholder="G5, Plat" />
+            </label>
+          </div>
+
+          <fieldset class="radio-group">
+            <legend>Victoire ?</legend>
+            <label><input type="radio" name="win" value="yes" required /> Oui</label>
+            <label><input type="radio" name="win" value="no" /> Non</label>
+          </fieldset>
+
+          <p id="form-error" class="error" role="alert" aria-live="polite"></p>
+          <button type="submit" class="btn primary">Ajouter</button>
+        </form>
+      </section>
+
+      <section class="stats" aria-live="polite">
+        <div class="card">
+          <h2>Global</h2>
+          <div id="global-stats" class="stats-grid"></div>
+        </div>
+
+        <div class="card">
+          <h2>Meilleures teams (min 5 combats)</h2>
+          <div id="best-teams"></div>
+        </div>
+
+        <div class="card">
+          <h2>Synergies (Top 5 paires, min 8 combats)</h2>
+          <div id="synergy-stats"></div>
+        </div>
+
+        <div class="card">
+          <h2>Teams adverses</h2>
+          <h3>Top 5 battues</h3>
+          <div id="opponents-beaten"></div>
+          <h3>Top 5 qui te battent</h3>
+          <div id="opponents-lost"></div>
+        </div>
+
+        <div class="card">
+          <h2>Ranks</h2>
+          <div id="rank-stats"></div>
+        </div>
+      </section>
+
+      <section class="footer-actions card">
+        <button id="export-btn" class="btn">Exporter JSON</button>
+        <label class="btn file-btn" for="import-file">Importer JSON</label>
+        <input id="import-file" type="file" accept="application/json" />
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,495 @@
+const STORAGE_KEY = 'raid_arena_fights';
+const BACKUP_DB_NAME = 'raid_arena_tracker_backup';
+const BACKUP_STORE_NAME = 'snapshots';
+const BACKUP_KEY = 'latest';
+
+const form = document.getElementById('fight-form');
+const playerTeamInput = document.getElementById('player-team');
+const opponentTeamInput = document.getElementById('opponent-team');
+const playerRankInput = document.getElementById('player-rank');
+const opponentRankInput = document.getElementById('opponent-rank');
+const formError = document.getElementById('form-error');
+const exportBtn = document.getElementById('export-btn');
+const importFileInput = document.getElementById('import-file');
+
+function titleCase(value) {
+  return value
+    .toLowerCase()
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function parseTeam(input) {
+  if (!input.trim()) {
+    return [];
+  }
+  return input
+    .split(',')
+    .map((name) => titleCase(name.trim()))
+    .filter(Boolean);
+}
+
+function validateTeam(team, label, required) {
+  if (team.length === 0 && required) {
+    throw new Error(`${label} : ajoute entre 1 et 4 champions.`);
+  }
+  if (team.length > 4) {
+    throw new Error(`${label} : maximum 4 champions.`);
+  }
+  if (!required && team.length !== 0 && team.length < 1) {
+    throw new Error(`${label} invalide.`);
+  }
+}
+
+function getTeamKey(team) {
+  return [...team].map(titleCase).sort((a, b) => a.localeCompare(b)).join(',');
+}
+
+function parseRank(value) {
+  if (!value || !value.trim()) {
+    return null;
+  }
+
+  const input = value.trim().toUpperCase();
+  if (input.startsWith('PLAT')) {
+    const number = Number.parseInt(input.replace(/[^0-9]/g, ''), 10);
+    return Number.isNaN(number) ? 14 : 14 + Math.max(0, number - 1);
+  }
+
+  const romanMap = { I: 1, II: 2, III: 3, IV: 4, V: 5 };
+  const shorthand = input.match(/^([BSG])\s*([1-5]|I|II|III|IV|V)$/);
+
+  if (shorthand) {
+    const tier = shorthand[1];
+    const rawDivision = shorthand[2];
+    const division = Number(rawDivision) || romanMap[rawDivision] || null;
+
+    if (!division) {
+      return null;
+    }
+
+    if (tier === 'B' && division <= 4) {
+      return division;
+    }
+    if (tier === 'S' && division <= 4) {
+      return 4 + division;
+    }
+    if (tier === 'G' && division <= 5) {
+      return 8 + division;
+    }
+    return null;
+  }
+
+  const longMatch = input.match(/^(BRONZE|SILVER|GOLD)\s*(I|II|III|IV|V|1|2|3|4|5)$/);
+  if (longMatch) {
+    const tier = longMatch[1];
+    const rawDivision = longMatch[2];
+    const division = Number(rawDivision) || romanMap[rawDivision] || null;
+    if (!division) {
+      return null;
+    }
+    if (tier === 'BRONZE' && division <= 4) {
+      return division;
+    }
+    if (tier === 'SILVER' && division <= 4) {
+      return 4 + division;
+    }
+    if (tier === 'GOLD' && division <= 5) {
+      return 8 + division;
+    }
+  }
+
+  return null;
+}
+
+function rankToStr(rankInt) {
+  if (!rankInt || rankInt < 1) {
+    return 'N/A';
+  }
+
+  const roman = ['', 'I', 'II', 'III', 'IV', 'V'];
+  if (rankInt <= 4) {
+    return `Bronze ${roman[rankInt]}`;
+  }
+  if (rankInt <= 8) {
+    return `Silver ${roman[rankInt - 4]}`;
+  }
+  if (rankInt <= 13) {
+    return `Gold ${roman[rankInt - 8]}`;
+  }
+  return rankInt === 14 ? 'Platinum' : `Platinum +${rankInt - 14}`;
+}
+
+function loadFights() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveFights(fights) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(fights));
+  void saveBackupSnapshot(fights);
+}
+
+function openBackupDb() {
+  return new Promise((resolve, reject) => {
+    if (!window.indexedDB) {
+      resolve(null);
+      return;
+    }
+
+    const request = window.indexedDB.open(BACKUP_DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(BACKUP_STORE_NAME)) {
+        db.createObjectStore(BACKUP_STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function saveBackupSnapshot(fights) {
+  try {
+    const db = await openBackupDb();
+    if (!db) {
+      return;
+    }
+
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(BACKUP_STORE_NAME, 'readwrite');
+      tx.objectStore(BACKUP_STORE_NAME).put(JSON.stringify(fights), BACKUP_KEY);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+  } catch {
+    // Backup silencieux: l'appli continue même si IndexedDB n'est pas disponible.
+  }
+}
+
+async function loadBackupSnapshot() {
+  try {
+    const db = await openBackupDb();
+    if (!db) {
+      return null;
+    }
+
+    const raw = await new Promise((resolve, reject) => {
+      const tx = db.transaction(BACKUP_STORE_NAME, 'readonly');
+      const request = tx.objectStore(BACKUP_STORE_NAME).get(BACKUP_KEY);
+      request.onsuccess = () => resolve(request.result || null);
+      request.onerror = () => reject(request.error);
+    });
+    db.close();
+
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function restoreFromBackupIfNeeded() {
+  if (loadFights().length > 0) {
+    return;
+  }
+
+  const backupFights = await loadBackupSnapshot();
+  if (!backupFights || backupFights.length === 0) {
+    return;
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(backupFights));
+  renderAllStats();
+}
+
+function computeWinrate(fights) {
+  if (!fights.length) {
+    return 0;
+  }
+  const wins = fights.filter((fight) => fight.win).length;
+  return (wins / fights.length) * 100;
+}
+
+function computeCurrentStreak(fights) {
+  if (!fights.length) {
+    return '0';
+  }
+  const lastResult = fights[fights.length - 1].win;
+  let count = 0;
+
+  for (let i = fights.length - 1; i >= 0; i -= 1) {
+    if (fights[i].win === lastResult) {
+      count += 1;
+    } else {
+      break;
+    }
+  }
+
+  return `${lastResult ? 'W' : 'L'} x${count}`;
+}
+
+function buildTable(headers, rows) {
+  if (!rows.length) {
+    return '<p class="empty">Pas assez de données.</p>';
+  }
+
+  const thead = `<thead><tr>${headers.map((h) => `<th>${h}</th>`).join('')}</tr></thead>`;
+  const tbody = `<tbody>${rows
+    .map((row) => `<tr>${row.map((cell) => `<td>${cell}</td>`).join('')}</tr>`)
+    .join('')}</tbody>`;
+  return `<table>${thead}${tbody}</table>`;
+}
+
+function renderGlobalStats(fights) {
+  const total = fights.length;
+  const winrate = computeWinrate(fights);
+  const streak = computeCurrentStreak(fights);
+  const lastTen = fights.slice(-10);
+  const lastTenWr = computeWinrate(lastTen);
+
+  document.getElementById('global-stats').innerHTML = `
+    <div class="stat-item"><span class="label">Total combats</span><div class="value">${total}</div></div>
+    <div class="stat-item"><span class="label">Winrate global</span><div class="value">${winrate.toFixed(1)}%</div></div>
+    <div class="stat-item"><span class="label">Streak actuelle</span><div class="value">${streak}</div></div>
+    <div class="stat-item"><span class="label">Derniers 10</span><div class="value">${lastTenWr.toFixed(1)}%</div></div>
+  `;
+}
+
+function renderBestTeams(fights) {
+  const grouped = new Map();
+
+  fights.forEach((fight) => {
+    const key = getTeamKey(fight.player_team || []);
+    if (!key) {
+      return;
+    }
+    if (!grouped.has(key)) {
+      grouped.set(key, []);
+    }
+    grouped.get(key).push(fight);
+  });
+
+  const rows = [...grouped.entries()]
+    .map(([team, teamFights]) => ({
+      team,
+      count: teamFights.length,
+      wr: computeWinrate(teamFights),
+    }))
+    .filter((entry) => entry.count >= 5)
+    .sort((a, b) => b.wr - a.wr || b.count - a.count)
+    .map((entry) => [entry.team, `${entry.wr.toFixed(1)}%`, entry.count]);
+
+  document.getElementById('best-teams').innerHTML = buildTable(['Team', 'WR', 'Combats'], rows);
+}
+
+function renderSynergies(fights) {
+  const pairMap = new Map();
+  const globalWr = computeWinrate(fights);
+
+  fights.forEach((fight) => {
+    const uniqueTeam = [...new Set((fight.player_team || []).map(titleCase))];
+    for (let i = 0; i < uniqueTeam.length; i += 1) {
+      for (let j = i + 1; j < uniqueTeam.length; j += 1) {
+        const pair = [uniqueTeam[i], uniqueTeam[j]].sort((a, b) => a.localeCompare(b)).join(' + ');
+        if (!pairMap.has(pair)) {
+          pairMap.set(pair, []);
+        }
+        pairMap.get(pair).push(fight);
+      }
+    }
+  });
+
+  const rows = [...pairMap.entries()]
+    .map(([pair, pairFights]) => {
+      const wr = computeWinrate(pairFights);
+      return {
+        pair,
+        fights: pairFights.length,
+        wr,
+        delta: wr - globalWr,
+      };
+    })
+    .filter((entry) => entry.fights >= 8)
+    .sort((a, b) => b.wr - a.wr || b.fights - a.fights)
+    .slice(0, 5)
+    .map((entry) => [entry.pair, `${entry.wr.toFixed(1)}%`, `${entry.delta >= 0 ? '+' : ''}${entry.delta.toFixed(1)}%`, entry.fights]);
+
+  document.getElementById('synergy-stats').innerHTML = buildTable(
+    ['Paire', 'WR', 'Delta vs global', 'Combats'],
+    rows,
+  );
+}
+
+function renderOpponentStats(fights) {
+  const grouped = new Map();
+
+  fights.forEach((fight) => {
+    const team = getTeamKey(fight.opponent_team || []);
+    if (!team) {
+      return;
+    }
+    if (!grouped.has(team)) {
+      grouped.set(team, []);
+    }
+    grouped.get(team).push(fight);
+  });
+
+  const beatenRows = [...grouped.entries()]
+    .map(([team, teamFights]) => ({
+      team,
+      wins: teamFights.filter((fight) => fight.win).length,
+    }))
+    .filter((entry) => entry.wins > 0)
+    .sort((a, b) => b.wins - a.wins)
+    .slice(0, 5)
+    .map((entry) => [entry.team, entry.wins]);
+
+  const lostRows = [...grouped.entries()]
+    .map(([team, teamFights]) => ({
+      team,
+      losses: teamFights.filter((fight) => !fight.win).length,
+    }))
+    .filter((entry) => entry.losses > 0)
+    .sort((a, b) => b.losses - a.losses)
+    .slice(0, 5)
+    .map((entry) => [entry.team, entry.losses]);
+
+  document.getElementById('opponents-beaten').innerHTML = buildTable(['Team adverse', 'Victoires'], beatenRows);
+  document.getElementById('opponents-lost').innerHTML = buildTable(['Team adverse', 'Défaites'], lostRows);
+}
+
+function renderRankStats(fights) {
+  const playerRanks = fights
+    .map((fight) => parseRank(fight.player_rank_str || ''))
+    .filter((rank) => rank !== null);
+  const bestRank = playerRanks.length ? Math.max(...playerRanks) : null;
+
+  const rankedOpponents = fights.filter((fight) => parseRank(fight.opponent_rank_str || '') !== null);
+  let wrVsStronger = 0;
+  let wrVsLower = 0;
+
+  if (rankedOpponents.length) {
+    const stronger = rankedOpponents.filter(
+      (fight) => parseRank(fight.opponent_rank_str) > parseRank(fight.player_rank_str),
+    );
+    const lower = rankedOpponents.filter(
+      (fight) => parseRank(fight.opponent_rank_str) < parseRank(fight.player_rank_str),
+    );
+
+    wrVsStronger = computeWinrate(stronger);
+    wrVsLower = computeWinrate(lower);
+  }
+
+  document.getElementById('rank-stats').innerHTML = `
+    <div class="stats-grid">
+      <div class="stat-item"><span class="label">Meilleur rank atteint</span><div class="value">${
+        bestRank ? rankToStr(bestRank) : 'N/A'
+      }</div></div>
+      <div class="stat-item"><span class="label">WR vs plus fort</span><div class="value">${wrVsStronger.toFixed(
+        1,
+      )}%</div></div>
+      <div class="stat-item"><span class="label">WR vs plus faible</span><div class="value">${wrVsLower.toFixed(
+        1,
+      )}%</div></div>
+    </div>
+  `;
+}
+
+function renderAllStats() {
+  const fights = loadFights();
+  renderGlobalStats(fights);
+  renderBestTeams(fights);
+  renderSynergies(fights);
+  renderOpponentStats(fights);
+  renderRankStats(fights);
+}
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  formError.textContent = '';
+
+  try {
+    const playerTeam = parseTeam(playerTeamInput.value);
+    const opponentTeam = parseTeam(opponentTeamInput.value);
+    validateTeam(playerTeam, 'Team joueur', true);
+    if (opponentTeamInput.value.trim()) {
+      validateTeam(opponentTeam, 'Team adverse', true);
+    }
+
+    if (!playerRankInput.value.trim()) {
+      throw new Error('Rank joueur obligatoire.');
+    }
+
+    const winChoice = form.querySelector('input[name="win"]:checked');
+    if (!winChoice) {
+      throw new Error('Indique si le combat est une victoire ou une défaite.');
+    }
+
+    const fights = loadFights();
+    fights.push({
+      timestamp: Date.now(),
+      player_team: playerTeam,
+      opponent_team: opponentTeam,
+      player_rank_str: playerRankInput.value.trim(),
+      opponent_rank_str: opponentRankInput.value.trim(),
+      win: winChoice.value === 'yes',
+    });
+
+    saveFights(fights);
+    form.reset();
+    renderAllStats();
+  } catch (error) {
+    formError.textContent = error.message;
+  }
+});
+
+exportBtn.addEventListener('click', () => {
+  const fights = loadFights();
+  const blob = new Blob([JSON.stringify(fights, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'raid-arena-data.json';
+  link.click();
+  URL.revokeObjectURL(url);
+});
+
+importFileInput.addEventListener('change', async (event) => {
+  const file = event.target.files?.[0];
+  if (!file) {
+    return;
+  }
+
+  try {
+    const text = await file.text();
+    const parsed = JSON.parse(text);
+    if (!Array.isArray(parsed)) {
+      throw new Error('Le JSON importé doit être un tableau de combats.');
+    }
+    saveFights(parsed);
+    renderAllStats();
+  } catch (error) {
+    formError.textContent = `Import impossible : ${error.message}`;
+  } finally {
+    importFileInput.value = '';
+  }
+});
+
+renderAllStats();
+void restoreFromBackupIfNeeded();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,184 @@
+:root {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --panel: #161b22;
+  --panel-2: #1f2937;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --accent: #3b82f6;
+  --accent-hover: #2563eb;
+  --danger: #ef4444;
+  --border: #30363d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: radial-gradient(circle at top, #111827, var(--bg));
+  color: var(--text);
+}
+
+.container {
+  width: min(1100px, 100% - 2rem);
+  margin: 1rem auto 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(1.2rem, 3vw, 2rem);
+}
+
+.subtitle {
+  margin-top: 0.35rem;
+  color: var(--muted);
+}
+
+.card {
+  background: linear-gradient(180deg, var(--panel), #121821);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+label,
+legend {
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+input[type='text'] {
+  margin-top: 0.35rem;
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-2);
+  color: var(--text);
+}
+
+.radio-group {
+  margin: 1rem 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.error {
+  margin: 0.5rem 0 0.8rem;
+  min-height: 1.2rem;
+  color: var(--danger);
+}
+
+.btn {
+  cursor: pointer;
+  padding: 0.7rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #1e293b;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.btn:hover {
+  filter: brightness(1.1);
+}
+
+.btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.btn.primary:hover {
+  background: var(--accent-hover);
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.stat-item {
+  background: #0f172a;
+  border-radius: 8px;
+  padding: 0.7rem;
+  border: 1px solid var(--border);
+}
+
+.stat-item .label {
+  display: block;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.stat-item .value {
+  font-weight: 700;
+  margin-top: 0.25rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+th,
+td {
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  padding: 0.45rem 0.25rem;
+}
+
+.footer-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+#import-file {
+  display: none;
+}
+
+.file-btn {
+  text-align: center;
+}
+
+.empty {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 800px) {
+  .form-grid,
+  .stats,
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .container {
+    width: min(700px, 100% - 1rem);
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a small 100% local web app to track Classic 4v4 Arena fights and keep player stats without any backend. 
- Ensure data persistence and recoverability via browser `localStorage` and an automatic `IndexedDB` backup. 
- Offer simple import/export JSON and UI for quick manual backups and multi-device syncing. 

### Description

- Added a complete static UI in `index.html` and styling in `style.css` for entering fights, viewing stats, and importing/exporting data. 
- Implemented core logic in `script.js` that stores fights under `localStorage` key `raid_arena_fights`, maintains a silent backup in IndexedDB (`raid_arena_tracker_backup`), and restores from backup when needed. 
- Normalizes inputs (`titleCase`), parses and maps ranks (`parseRank` / `rankToStr`), validates teams, and computes stats including global winrate, current streak, best teams, synergies, opponent aggregates, and rank-based WRs. 
- Updated `README.md` with installation, usage, storage details, data schema, and import/export instructions. 

### Testing

- No automated tests are configured or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c3b97b24832286d50763aec390c1)