### PR TITLE
Add champion pool persistence and datalist suggestions for team inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
                 type="text"
                 id="player-team"
                 required
+                list="champion-options"
                 placeholder="Arbiter, Duchess Lilitu, Mithrala, Rotos"
               />
             </label>
@@ -35,6 +36,7 @@
               <input
                 type="text"
                 id="opponent-team"
+                list="champion-options"
                 placeholder="Siphi, Rotos"
               />
             </label>
@@ -59,6 +61,7 @@
           <p id="form-error" class="error" role="alert" aria-live="polite"></p>
           <button type="submit" class="btn primary">Ajouter</button>
         </form>
+        <datalist id="champion-options"></datalist>
       </section>
 
       <section class="stats" aria-live="polite">

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ const STORAGE_KEY = 'raid_arena_fights';
 const BACKUP_DB_NAME = 'raid_arena_tracker_backup';
 const BACKUP_STORE_NAME = 'snapshots';
 const BACKUP_KEY = 'latest';
+const CHAMPION_POOL_KEY = 'raid_arena_champion_pool';
 
 const form = document.getElementById('fight-form');
 const playerTeamInput = document.getElementById('player-team');
@@ -9,6 +10,7 @@ const opponentTeamInput = document.getElementById('opponent-team');
 const playerRankInput = document.getElementById('player-rank');
 const opponentRankInput = document.getElementById('opponent-rank');
 const formError = document.getElementById('form-error');
+const championOptions = document.getElementById('champion-options');
 const exportBtn = document.getElementById('export-btn');
 const importFileInput = document.getElementById('import-file');
 
@@ -133,6 +135,41 @@ function loadFights() {
   } catch {
     return [];
   }
+}
+
+
+function loadChampionPool() {
+  try {
+    const raw = localStorage.getItem(CHAMPION_POOL_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.map(titleCase).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function saveChampionPool(champions) {
+  localStorage.setItem(CHAMPION_POOL_KEY, JSON.stringify(champions));
+}
+
+function upsertChampionPoolFromTeams(teams) {
+  const existing = new Set(loadChampionPool());
+
+  teams
+    .flat()
+    .map(titleCase)
+    .filter(Boolean)
+    .forEach((champion) => existing.add(champion));
+
+  saveChampionPool([...existing].sort((a, b) => a.localeCompare(b)));
 }
 
 function saveFights(fights) {
@@ -411,8 +448,29 @@ function renderRankStats(fights) {
   `;
 }
 
+function renderChampionSuggestions(fights) {
+  const champions = new Set(loadChampionPool());
+
+  fights.forEach((fight) => {
+    [...(fight.player_team || []), ...(fight.opponent_team || [])]
+      .map(titleCase)
+      .filter(Boolean)
+      .forEach((champion) => champions.add(champion));
+  });
+
+  const sortedChampions = [...champions].sort((a, b) => a.localeCompare(b));
+  saveChampionPool(sortedChampions);
+
+  const optionsHtml = sortedChampions
+    .map((champion) => `<option value="${champion}"></option>`)
+    .join('');
+
+  championOptions.innerHTML = optionsHtml;
+}
+
 function renderAllStats() {
   const fights = loadFights();
+  renderChampionSuggestions(fights);
   renderGlobalStats(fights);
   renderBestTeams(fights);
   renderSynergies(fights);
@@ -441,6 +499,8 @@ form.addEventListener('submit', (event) => {
       throw new Error('Indique si le combat est une victoire ou une défaite.');
     }
 
+    upsertChampionPoolFromTeams([playerTeam, opponentTeam]);
+
     const fights = loadFights();
     fights.push({
       timestamp: Date.now(),
@@ -457,6 +517,17 @@ form.addEventListener('submit', (event) => {
   } catch (error) {
     formError.textContent = error.message;
   }
+});
+
+[playerTeamInput, opponentTeamInput].forEach((input) => {
+  input.addEventListener('change', () => {
+    const team = parseTeam(input.value);
+    if (!team.length) {
+      return;
+    }
+    upsertChampionPoolFromTeams([team]);
+    renderChampionSuggestions(loadFights());
+  });
 });
 
 exportBtn.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Provide autocomplete suggestions for champion names to speed up data entry and ensure consistent capitalization.
- Persist a global champion pool in localStorage so suggestions survive reloads and imports.
- Keep the champion pool up-to-date automatically from submitted or edited teams to reduce manual maintenance.

### Description
- Added a `<datalist id="champion-options">` to `index.html` and wired it to the player/opponent team inputs via the `list` attribute. 
- Introduced `CHAMPION_POOL_KEY` and `championOptions` in `script.js` and implemented `loadChampionPool`, `saveChampionPool`, and `upsertChampionPoolFromTeams` to store a sorted, title-cased champion list in localStorage. 
- Added `renderChampionSuggestions` to merge champions from existing fights and the pool, render `<option>` entries into the datalist, and call it from `renderAllStats`. 
- Updated form handling to call `upsertChampionPoolFromTeams` on submit and added `change` listeners on team inputs to update the pool as users type or edit teams.

### Testing
- No automated tests were added or modified for this change. 
- The change is self-contained to the frontend and exercises storage and rendering logic when submitting fights and editing team inputs using the existing runtime. 
- Basic local verification was performed to confirm datalist options populate and persist across reloads (manual smoke checks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6cbe36d1c8322bdd53c8b71a3340f)