### PR TITLE
Corrige autocomplétion multi-champions dans le champ Team

### DIFF
--- a/script.js
+++ b/script.js
@@ -318,13 +318,17 @@ function attachTeamAutocomplete(input) {
     const currentValue = input.value;
     const selectedChampion = titleCase(currentValue.trim());
 
-    if (
-      previousValue.includes(',')
-      && !currentValue.includes(',')
-      && champions.includes(selectedChampion)
-    ) {
-      const prefix = previousValue.slice(0, previousValue.lastIndexOf(',') + 1).trim();
-      input.value = `${prefix}, ${selectedChampion}`.replace(/^,\s*/, '');
+    if (previousValue.includes(',') && champions.includes(selectedChampion)) {
+      const lastCommaIndex = previousValue.lastIndexOf(',');
+      const prefixTokens = previousValue
+        .slice(0, lastCommaIndex)
+        .split(',')
+        .map((token) => titleCase(token.trim()))
+        .filter(Boolean);
+
+      if (prefixTokens.length) {
+        input.value = [...prefixTokens, selectedChampion].join(', ');
+      }
     }
 
     input.dataset.prevValue = input.value;


### PR DESCRIPTION
### Motivation
- L'autocomplétion du champ d'équipe produisait des valeurs mal formées quand un champion était sélectionné après une virgule à cause d'une concaténation de chaîne fragile; l'objectif est de conserver proprement les champions déjà saisis et d'ajouter le champion sélectionné.

### Description
- La logique de `attachTeamAutocomplete` a été modifiée pour reconstruire le préfixe en tokens avant la dernière virgule, normaliser chaque token avec `titleCase` et réassembler la valeur via `join(', ')` au lieu d'une simple concaténation.
- La condition fragile qui dépendait de l'absence de virgule dans `currentValue` a été remplacée par un contrôle qui vérifie que des tokens préexistants existent et que le champion sélectionné figure dans la liste chargée (`loadChampionPool`).

### Testing
- La vérification de syntaxe JavaScript a été exécutée avec `node --check script.js` et a réussi.
- Aucun autre test automatisé n'a été ajouté pour cette correction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6de1c2d1c8322b4ea0774b86d0322)