### PR TITLE
Add slot-based team entry to fix autocomplete reliability

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,34 +29,31 @@
         <h2 id="add-fight-title" data-i18n="form.title">Ajouter combat</h2>
         <form id="fight-form" novalidate>
           <div class="form-grid">
-            <label>
-              <span data-i18n="form.playerTeamLabel">Team joueur (1 à 4 champions)</span>
-              <input
-                type="text"
-                id="player-team"
-                required
-                list="champion-options"
-                placeholder="Arbiter, Duchess Lilitu, Mithrala, Rotos"
-                data-i18n-placeholder="form.playerTeamPlaceholder"
-              />
+            <fieldset class="team-fieldset">
+              <legend data-i18n="form.playerTeamLabel">Team joueur (1 à 4 champions)</legend>
+              <div class="team-slots" id="player-team-slots">
+                <input type="text" id="player-slot-1" list="champion-options" placeholder="Slot 1" aria-label="Player slot 1" />
+                <input type="text" id="player-slot-2" list="champion-options" placeholder="Slot 2" aria-label="Player slot 2" />
+                <input type="text" id="player-slot-3" list="champion-options" placeholder="Slot 3" aria-label="Player slot 3" />
+                <input type="text" id="player-slot-4" list="champion-options" placeholder="Slot 4" aria-label="Player slot 4" />
+              </div>
               <div class="inline-option">
                 <label class="checkbox-label">
                   <input type="checkbox" id="lock-player-team" />
                   <span data-i18n="form.lockTeam">Verrouiller mon équipe (réutilisée automatiquement)</span>
                 </label>
               </div>
-            </label>
+            </fieldset>
 
-            <label>
-              <span data-i18n="form.opponentTeamLabel">Team adverse (optionnel, 1 à 4)</span>
-              <input
-                type="text"
-                id="opponent-team"
-                list="champion-options"
-                placeholder="Siphi, Rotos"
-                data-i18n-placeholder="form.opponentTeamPlaceholder"
-              />
-            </label>
+            <fieldset class="team-fieldset">
+              <legend data-i18n="form.opponentTeamLabel">Team adverse (optionnel, 1 à 4)</legend>
+              <div class="team-slots" id="opponent-team-slots">
+                <input type="text" id="opponent-slot-1" list="champion-options" placeholder="Slot 1" aria-label="Opponent slot 1" />
+                <input type="text" id="opponent-slot-2" list="champion-options" placeholder="Slot 2" aria-label="Opponent slot 2" />
+                <input type="text" id="opponent-slot-3" list="champion-options" placeholder="Slot 3" aria-label="Opponent slot 3" />
+                <input type="text" id="opponent-slot-4" list="champion-options" placeholder="Slot 4" aria-label="Opponent slot 4" />
+              </div>
+            </fieldset>
           </div>
 
           <fieldset class="radio-group">

--- a/script.js
+++ b/script.js
@@ -7,8 +7,8 @@ const PLAYER_TEAM_LOCK_KEY = 'raid_arena_player_team_lock';
 const LANGUAGE_KEY = 'raid_arena_language';
 
 const form = document.getElementById('fight-form');
-const playerTeamInput = document.getElementById('player-team');
-const opponentTeamInput = document.getElementById('opponent-team');
+const playerTeamSlots = [1, 2, 3, 4].map((slot) => document.getElementById(`player-slot-${slot}`));
+const opponentTeamSlots = [1, 2, 3, 4].map((slot) => document.getElementById(`opponent-slot-${slot}`));
 const lockPlayerTeamInput = document.getElementById('lock-player-team');
 const formError = document.getElementById('form-error');
 const championOptions = document.getElementById('champion-options');
@@ -120,14 +120,8 @@ function titleCase(value) {
     .join(' ');
 }
 
-function parseTeam(input) {
-  if (!input.trim()) {
-    return [];
-  }
-  return input
-    .split(',')
-    .map((name) => titleCase(name.trim()))
-    .filter(Boolean);
+function parseTeamFromSlots(inputs) {
+  return inputs.map((input) => titleCase(input.value.trim())).filter(Boolean);
 }
 
 function validateTeam(team, label, required) {
@@ -282,13 +276,10 @@ function savePlayerTeamLock(lockData) {
   localStorage.setItem(PLAYER_TEAM_LOCK_KEY, JSON.stringify(lockData));
 }
 
-function teamToInputValue(team) {
-  return team.map(titleCase).filter(Boolean).join(', ');
-}
-
-function getCurrentChampionToken(rawInputValue) {
-  const parts = rawInputValue.split(',');
-  return parts.length ? parts[parts.length - 1].trim() : rawInputValue.trim();
+function fillTeamSlots(inputs, team) {
+  inputs.forEach((input, index) => {
+    input.value = team[index] || '';
+  });
 }
 
 function renderChampionOptions(champions, token = '') {
@@ -304,35 +295,18 @@ function renderChampionOptions(champions, token = '') {
 }
 
 function attachTeamAutocomplete(input) {
-  input.dataset.prevValue = input.value;
-
   input.addEventListener('focus', () => {
     const champions = loadChampionPool().sort((a, b) => a.localeCompare(b));
-    renderChampionOptions(champions, getCurrentChampionToken(input.value));
-    input.dataset.prevValue = input.value;
+    renderChampionOptions(champions, input.value);
   });
 
   input.addEventListener('input', () => {
     const champions = loadChampionPool().sort((a, b) => a.localeCompare(b));
-    const previousValue = input.dataset.prevValue || '';
-    const currentValue = input.value;
-    const selectedChampion = titleCase(currentValue.trim());
+    renderChampionOptions(champions, input.value);
+  });
 
-    if (previousValue.includes(',') && champions.includes(selectedChampion)) {
-      const lastCommaIndex = previousValue.lastIndexOf(',');
-      const prefixTokens = previousValue
-        .slice(0, lastCommaIndex)
-        .split(',')
-        .map((token) => titleCase(token.trim()))
-        .filter(Boolean);
-
-      if (prefixTokens.length) {
-        input.value = [...prefixTokens, selectedChampion].join(', ');
-      }
-    }
-
-    input.dataset.prevValue = input.value;
-    renderChampionOptions(champions, getCurrentChampionToken(input.value));
+  input.addEventListener('change', () => {
+    input.value = titleCase(input.value.trim());
   });
 }
 
@@ -655,12 +629,10 @@ form.addEventListener('submit', (event) => {
 
   try {
     const lockData = loadPlayerTeamLock();
-    const playerTeam = lockData.locked ? lockData.team : parseTeam(playerTeamInput.value);
-    const opponentTeam = parseTeam(opponentTeamInput.value);
+    const playerTeam = lockData.locked ? lockData.team : parseTeamFromSlots(playerTeamSlots);
+    const opponentTeam = parseTeamFromSlots(opponentTeamSlots);
     validateTeam(playerTeam, t('messages.playerTeam'), true);
-    if (opponentTeamInput.value.trim()) {
-      validateTeam(opponentTeam, t('stats.opponentTeam'), true);
-    }
+    validateTeam(opponentTeam, t('stats.opponentTeam'), false);
 
 
     const winChoice = form.querySelector('input[name="win"]:checked');
@@ -684,8 +656,10 @@ form.addEventListener('submit', (event) => {
     const refreshedLockData = loadPlayerTeamLock();
     if (refreshedLockData.locked && refreshedLockData.team.length) {
       lockPlayerTeamInput.checked = true;
-      playerTeamInput.value = teamToInputValue(refreshedLockData.team);
-      playerTeamInput.readOnly = true;
+      fillTeamSlots(playerTeamSlots, refreshedLockData.team);
+      playerTeamSlots.forEach((slot) => {
+        slot.readOnly = true;
+      });
     }
 
     renderAllStats();
@@ -699,50 +673,57 @@ lockPlayerTeamInput.addEventListener('change', () => {
 
   if (!lockPlayerTeamInput.checked) {
     savePlayerTeamLock({ locked: false, team: [] });
-    playerTeamInput.readOnly = false;
+    playerTeamSlots.forEach((slot) => {
+      slot.readOnly = false;
+    });
     return;
   }
 
   try {
-    const team = parseTeam(playerTeamInput.value);
+    const team = parseTeamFromSlots(playerTeamSlots);
     validateTeam(team, t('messages.playerTeam'), true);
     const normalizedTeam = team.map(titleCase);
     savePlayerTeamLock({ locked: true, team: normalizedTeam });
-    playerTeamInput.value = teamToInputValue(normalizedTeam);
-    playerTeamInput.readOnly = true;
+    fillTeamSlots(playerTeamSlots, normalizedTeam);
+    playerTeamSlots.forEach((slot) => {
+      slot.readOnly = true;
+    });
   } catch (error) {
     lockPlayerTeamInput.checked = false;
     formError.textContent = t('messages.lockImpossible', { error: error.message });
   }
 });
 
-playerTeamInput.addEventListener('blur', () => {
-  if (playerTeamInput.readOnly) {
-    return;
-  }
+[...playerTeamSlots, ...opponentTeamSlots].forEach((slot) => {
+  slot.addEventListener('blur', () => {
+    if (slot.readOnly) {
+      return;
+    }
+    slot.value = titleCase(slot.value.trim());
+  });
 
-  const normalizedTeam = parseTeam(playerTeamInput.value);
-  playerTeamInput.value = teamToInputValue(normalizedTeam);
+  attachTeamAutocomplete(slot);
 });
-
-attachTeamAutocomplete(playerTeamInput);
-attachTeamAutocomplete(opponentTeamInput);
 
 const initialLockData = loadPlayerTeamLock();
 if (initialLockData.locked && initialLockData.team.length) {
   lockPlayerTeamInput.checked = true;
-  playerTeamInput.value = teamToInputValue(initialLockData.team);
-  playerTeamInput.readOnly = true;
+  fillTeamSlots(playerTeamSlots, initialLockData.team);
+  playerTeamSlots.forEach((slot) => {
+    slot.readOnly = true;
+  });
 }
 
-[playerTeamInput, opponentTeamInput].forEach((input) => {
-  input.addEventListener('change', () => {
-    const team = parseTeam(input.value);
-    if (!team.length) {
-      return;
-    }
-    upsertChampionPoolFromTeams([team]);
-    renderChampionSuggestions(loadFights());
+[playerTeamSlots, opponentTeamSlots].forEach((teamSlots) => {
+  teamSlots.forEach((input) => {
+    input.addEventListener('change', () => {
+      const team = parseTeamFromSlots(teamSlots);
+      if (!team.length) {
+        return;
+      }
+      upsertChampionPoolFromTeams([team]);
+      renderChampionSuggestions(loadFights());
+    });
   });
 });
 

--- a/style.css
+++ b/style.css
@@ -103,6 +103,23 @@ input[type='text'] {
   color: var(--text);
 }
 
+.team-fieldset {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin: 0;
+}
+
+.team-slots {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.team-slots input[type='text'] {
+  margin-top: 0;
+}
+
 .radio-group {
   margin: 1rem 0;
   border: 1px solid var(--border);
@@ -218,7 +235,8 @@ td {
 @media (max-width: 800px) {
   .form-grid,
   .stats,
-  .stats-grid {
+  .stats-grid,
+  .team-slots {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
### Motivation

- The single comma-separated team input made per-champion autocompletion fragile and hard to normalize, so the UI needed explicit slots per champion. 
- The change keeps existing stored data shapes (`player_team` / `opponent_team` arrays) and preserves the player-team lock behaviour.

### Description

- Replace the comma-separated player/opponent text inputs with four slot inputs each in `index.html` (`player-slot-1..4`, `opponent-slot-1..4`).
- Simplify autocomplete to operate per-slot in `script.js` by introducing `playerTeamSlots` / `opponentTeamSlots`, `parseTeamFromSlots`, `fillTeamSlots` and a per-input `attachTeamAutocomplete` handler that normalizes on `change`/`blur`.
- Update submit and lock logic to read/write the 4 slots, maintain `player_team`/`opponent_team` arrays, and preserve saved lock data via `loadPlayerTeamLock` / `savePlayerTeamLock`.
- Add slot styling and responsive layout in `style.css` (`.team-fieldset`, `.team-slots`) and wire up the changes throughout the codebase.

### Testing

- Ran `node --check script.js` to validate JavaScript syntax and it succeeded. 
- Launched a local static server with `python3 -m http.server 4173` and performed a visual smoke test with Playwright which produced the screenshot artifact `artifacts/team-slots.png` successfully. 
- Verified the UI interactions manually in the Playwright run (server responded and page loaded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6defdd3e083228525bdc8ca15bd90)