### PR TITLE
Use 'Leader' for slot 1 and preserve team order in reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             <fieldset class="team-fieldset">
               <legend data-i18n="form.playerTeamLabel">Team joueur (1 à 4 champions)</legend>
               <div class="team-slots" id="player-team-slots">
-                <input type="text" id="player-slot-1" list="champion-options" placeholder="Slot 1" aria-label="Player slot 1" />
+                <input type="text" id="player-slot-1" list="champion-options" placeholder="Leader" aria-label="Player slot 1" />
                 <input type="text" id="player-slot-2" list="champion-options" placeholder="Slot 2" aria-label="Player slot 2" />
                 <input type="text" id="player-slot-3" list="champion-options" placeholder="Slot 3" aria-label="Player slot 3" />
                 <input type="text" id="player-slot-4" list="champion-options" placeholder="Slot 4" aria-label="Player slot 4" />
@@ -48,7 +48,7 @@
             <fieldset class="team-fieldset">
               <legend data-i18n="form.opponentTeamLabel">Team adverse (optionnel, 1 à 4)</legend>
               <div class="team-slots" id="opponent-team-slots">
-                <input type="text" id="opponent-slot-1" list="champion-options" placeholder="Slot 1" aria-label="Opponent slot 1" />
+                <input type="text" id="opponent-slot-1" list="champion-options" placeholder="Leader" aria-label="Opponent slot 1" />
                 <input type="text" id="opponent-slot-2" list="champion-options" placeholder="Slot 2" aria-label="Opponent slot 2" />
                 <input type="text" id="opponent-slot-3" list="champion-options" placeholder="Slot 3" aria-label="Opponent slot 3" />
                 <input type="text" id="opponent-slot-4" list="champion-options" placeholder="Slot 4" aria-label="Opponent slot 4" />

--- a/script.js
+++ b/script.js
@@ -137,7 +137,7 @@ function validateTeam(team, label, required) {
 }
 
 function getTeamKey(team) {
-  return [...team].map(titleCase).sort((a, b) => a.localeCompare(b)).join(',');
+  return [...team].map(titleCase).join(',');
 }
 
 function parseRank(value) {


### PR DESCRIPTION
### Motivation
- Make the slot 1 placeholder clearer by labeling it `Leader` for both player and opponent inputs. 
- Keep the original team slot order when grouping/rendering fight reports instead of reordering champions alphabetically.

### Description
- Updated `index.html` to change the placeholder for `player-slot-1` and `opponent-slot-1` to `Leader`.
- Modified `getTeamKey` in `script.js` to return the team in the entered order (`titleCase` applied) instead of sorting the names, preserving slot order in stats and reports.
- This change ensures team labels in the various stats tables match the original slot order used when the fight was recorded.

### Testing
- Ran `node --check script.js` to validate JavaScript syntax, which succeeded.
- Served the app with `python3 -m http.server 4173` and ran a headless Playwright script that captured `artifacts/leader-slot.png` to verify the UI change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e0f72a5c8322b9e7b98c7a3e6dd5)