### PR TITLE
Run Lint Review on pushes to main/master

### DIFF
--- a/.github/workflows/lint-review.yml
+++ b/.github/workflows/lint-review.yml
@@ -1,6 +1,10 @@
 name: Lint Review
 
 on:
+  push:
+    branches:
+      - main
+      - master
   pull_request:
     branches:
       - main


### PR DESCRIPTION
### Motivation
- Enable the existing ESLint workflow to run on direct pushes to `main` and `master` in addition to pull requests so linting is enforced on branch updates.

### Description
- Updated `.github/workflows/lint-review.yml` to add a `push` trigger for the `main` and `master` branches while keeping the existing `pull_request` and `workflow_dispatch` triggers intact.

### Testing
- No automated tests were executed as part of this change; the workflow modification will cause the `ESLint` job to run on subsequent pushes to `main`/`master` in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6fef2463883228cd65a0228c33a3f)