### PR TITLE
Rework team slot layout using CSS grid areas and add slot classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,10 @@
             <fieldset class="team-fieldset">
               <legend data-i18n="form.playerTeamLabel">Team joueur (1 à 4 champions)</legend>
               <div class="team-slots" id="player-team-slots">
-                <input type="text" id="player-slot-1" list="champion-options" placeholder="Leader" aria-label="Player slot 1" />
-                <input type="text" id="player-slot-2" list="champion-options" placeholder="Slot 2" aria-label="Player slot 2" />
-                <input type="text" id="player-slot-3" list="champion-options" placeholder="Slot 3" aria-label="Player slot 3" />
-                <input type="text" id="player-slot-4" list="champion-options" placeholder="Slot 4" aria-label="Player slot 4" />
+                <input type="text" id="player-slot-1" class="team-slot team-slot-1" list="champion-options" placeholder="1 (Leader)" aria-label="Player slot 1" />
+                <input type="text" id="player-slot-2" class="team-slot team-slot-2" list="champion-options" placeholder="2" aria-label="Player slot 2" />
+                <input type="text" id="player-slot-3" class="team-slot team-slot-3" list="champion-options" placeholder="3" aria-label="Player slot 3" />
+                <input type="text" id="player-slot-4" class="team-slot team-slot-4" list="champion-options" placeholder="4" aria-label="Player slot 4" />
               </div>
               <div class="inline-option">
                 <label class="checkbox-label">
@@ -49,10 +49,10 @@
             <fieldset class="team-fieldset">
               <legend data-i18n="form.opponentTeamLabel">Team adverse (optionnel, 1 à 4)</legend>
               <div class="team-slots" id="opponent-team-slots">
-                <input type="text" id="opponent-slot-1" list="champion-options" placeholder="Leader" aria-label="Opponent slot 1" />
-                <input type="text" id="opponent-slot-2" list="champion-options" placeholder="Slot 2" aria-label="Opponent slot 2" />
-                <input type="text" id="opponent-slot-3" list="champion-options" placeholder="Slot 3" aria-label="Opponent slot 3" />
-                <input type="text" id="opponent-slot-4" list="champion-options" placeholder="Slot 4" aria-label="Opponent slot 4" />
+                <input type="text" id="opponent-slot-1" class="team-slot team-slot-1" list="champion-options" placeholder="1 (Leader)" aria-label="Opponent slot 1" />
+                <input type="text" id="opponent-slot-2" class="team-slot team-slot-2" list="champion-options" placeholder="2" aria-label="Opponent slot 2" />
+                <input type="text" id="opponent-slot-3" class="team-slot team-slot-3" list="champion-options" placeholder="3" aria-label="Opponent slot 3" />
+                <input type="text" id="opponent-slot-4" class="team-slot team-slot-4" list="champion-options" placeholder="4" aria-label="Opponent slot 4" />
               </div>
             </fieldset>
           </div>

--- a/style.css
+++ b/style.css
@@ -112,12 +112,42 @@ input[type='text'] {
 
 .team-slots {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.6rem;
+}
+
+#player-team-slots {
+  grid-template-areas:
+    '. slot2 .'
+    'slot4 . slot1'
+    '. slot3 .';
+}
+
+#opponent-team-slots {
+  grid-template-areas:
+    '. slot2 .'
+    'slot1 . slot4'
+    '. slot3 .';
 }
 
 .team-slots input[type='text'] {
   margin-top: 0;
+}
+
+.team-slot-1 {
+  grid-area: slot1;
+}
+
+.team-slot-2 {
+  grid-area: slot2;
+}
+
+.team-slot-3 {
+  grid-area: slot3;
+}
+
+.team-slot-4 {
+  grid-area: slot4;
 }
 
 .radio-group {
@@ -238,6 +268,7 @@ td {
   .stats-grid,
   .team-slots {
     grid-template-columns: 1fr;
+    grid-template-areas: none;
   }
 
   .container {


### PR DESCRIPTION
### Motivation

- Improve the visual arrangement of player and opponent team input fields so the leader and slot positions are visually meaningful. 
- Make each input targetable via CSS by adding explicit slot classes for precise placement. 
- Ensure the layout adapts to small screens while keeping a three-column formation on wider viewports.

### Description

- Added `class="team-slot team-slot-N"` to each team input in `index.html` and adjusted placeholders to indicate slot numbers and leader. 
- Changed `.team-slots` grid from two to three columns and removed the top margin on `.team-slots input[type='text']` in `style.css`. 
- Introduced `#player-team-slots` and `#opponent-team-slots` grid `grid-template-areas` to place slots in formation and added `.team-slot-1`..`.team-slot-4` rules mapping to those areas. 
- Reset `grid-template-areas` to `none` in the mobile `@media (max-width: 800px)` rule so the layout collapses to a single column on small screens.

### Testing

- No automated tests were run for these UI/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71808bdf483229300e181d62357c6)