### PR TITLE
Ajoute un indicateur des persos/champions mémorisés dans le formulaire

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
           </fieldset>
 
           <p id="form-error" class="error" role="alert" aria-live="polite"></p>
+          <p id="champion-memory-indicator" class="memory-indicator" aria-live="polite"></p>
           <button type="submit" class="btn primary" data-i18n="form.submit">Ajouter</button>
         </form>
       </section>

--- a/script.js
+++ b/script.js
@@ -26,6 +26,7 @@ const syncChampionsBtn = document.getElementById('sync-champions-btn');
 const importFileInput = document.getElementById('import-file');
 const clearFightsBtn = document.getElementById('clear-fights-btn');
 const languageSelect = document.getElementById('language-select');
+const championMemoryIndicator = document.getElementById('champion-memory-indicator');
 
 
 const translations = {
@@ -35,7 +36,9 @@ const translations = {
     form: {
       title: 'Ajouter combat', playerTeamLabel: 'Team joueur (1 à 4 champions)', playerTeamPlaceholder: 'Arbiter, Duchess Lilitu, Mithrala, Rotos',
       lockTeam: 'Verrouiller mon équipe (réutilisée automatiquement)', opponentTeamLabel: 'Team adverse (optionnel, 1 à 4)', opponentTeamPlaceholder: 'Siphi, Rotos',
-      winLegend: 'Victoire ?', submit: 'Ajouter'
+      winLegend: 'Victoire ?', submit: 'Ajouter',
+      memoryCount: '{count} persos en mémoire.',
+      memoryPreview: 'Derniers mémorisés : {names}'
     },
     common: { yes: 'Oui', no: 'Non', na: 'N/A', notEnoughData: 'Pas assez de données.' },
     stats: {
@@ -63,7 +66,9 @@ const translations = {
     form: {
       title: 'Add fight', playerTeamLabel: 'Player team (1 to 4 champions)', playerTeamPlaceholder: 'Arbiter, Duchess Lilitu, Mithrala, Rotos',
       lockTeam: 'Lock my team (reused automatically)', opponentTeamLabel: 'Opponent team (optional, 1 to 4)', opponentTeamPlaceholder: 'Siphi, Rotos',
-      winLegend: 'Win?', submit: 'Add'
+      winLegend: 'Win?', submit: 'Add',
+      memoryCount: '{count} champions in memory.',
+      memoryPreview: 'Recently stored: {names}'
     },
     common: { yes: 'Yes', no: 'No', na: 'N/A', notEnoughData: 'Not enough data.' },
     stats: {
@@ -511,6 +516,20 @@ async function syncChampionPoolFromWeb() {
   }
 }
 
+function renderChampionMemoryIndicator() {
+  if (!championMemoryIndicator) {
+    return;
+  }
+
+  const champions = loadChampionPool();
+  const recent = champions.slice(-4);
+  const countText = t('form.memoryCount', { count: champions.length });
+
+  championMemoryIndicator.textContent = recent.length
+    ? `${countText} ${t('form.memoryPreview', { names: recent.join(', ') })}`
+    : countText;
+}
+
 function renderAllStats() {
   const fights = loadFights();
   renderChampionSuggestions(fights);
@@ -518,6 +537,7 @@ function renderAllStats() {
   renderBestTeams(fights);
   renderSynergies(fights);
   renderOpponentStats(fights);
+  renderChampionMemoryIndicator();
 }
 
 form.addEventListener('submit', (event) => {

--- a/style.css
+++ b/style.css
@@ -166,6 +166,12 @@ input[type='text'] {
   color: var(--danger);
 }
 
+.memory-indicator {
+  margin: 0 0 0.9rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
 .btn {
   cursor: pointer;
   padding: 0.7rem 1rem;


### PR DESCRIPTION
### Motivation

- Permettre à l'utilisateur de voir rapidement combien de champions sont déjà mémorisés localement et un aperçu des derniers noms ajoutés.

### Description

- Ajoute un élément DOM sous le formulaire avec l'id `champion-memory-indicator` pour afficher l'information (file: `index.html`).
- Ajoute les clés de traduction FR/EN `form.memoryCount` et `form.memoryPreview` et les utilise pour le texte affiché (file: `script.js`).
- Implémente `renderChampionMemoryIndicator()` qui lit `loadChampionPool()`, affiche le nombre total et jusqu'aux 4 derniers noms, et l'intègre dans le cycle de rendu via `renderAllStats()` (file: `script.js`).
- Ajoute la classe CSS `.memory-indicator` pour styliser l'indicateur (file: `style.css`).

### Testing

- Linting exécuté avec `npm run lint` et passé sans erreurs.
- Démarrage d'un serveur local avec `python -m http.server 4173` pour vérification UI automatisée.
- Vérification end-to-end automatique via script Playwright qui remplit le formulaire et capture un écran (capture générée comme preuve visuelle).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7330894dc83229b55aa5eb033968e)